### PR TITLE
Add unit tests for loan eligibility logic

### DIFF
--- a/src/test/java/com/miguel/lendingservice/controller/LoanControllerTest.java
+++ b/src/test/java/com/miguel/lendingservice/controller/LoanControllerTest.java
@@ -1,12 +1,64 @@
 package com.miguel.lendingservice.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.miguel.lendingservice.dto.LoanDTO;
+import com.miguel.lendingservice.dto.LoanRequest;
+import com.miguel.lendingservice.dto.LoanResponse;
+import com.miguel.lendingservice.model.LoanType;
+import com.miguel.lendingservice.service.LoanService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.result.StatusResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.math.BigDecimal;
+import java.util.List;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
 class LoanControllerTest {
 
+    @InjectMocks
+    private LoanController controller;
+    @Mock
+    private LoanService service;
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
     @Test
-    void getEligibleLoans() {
+    void getEligibleLoans_withValidInput_returnsCorrectLoans() throws Exception {
+        LoanRequest loanRequest = new LoanRequest(26, "275.484.389-23", "Vuxaywua Zukiagou",
+                BigDecimal.valueOf(7000.00), "SP");
+        LoanResponse mockResponse = new LoanResponse("Vuxaywua Zukiagou",
+                List.of(new LoanDTO(LoanType.PERSONAL, 5000.00),
+                        new LoanDTO(LoanType.GUARANTEED, 7000.00)));
+        when(service.determineEligibleLoans(any(LoanRequest.class))).thenReturn(mockResponse);
+        mockMvc.perform(post("/customer-loans")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsBytes(loanRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customer").value("Vuxaywua Zukiagou"))
+                .andExpect(jsonPath("$.loans[0].type").value("PERSONAL"))
+                .andExpect(jsonPath("$.loans[1].type").value("GUARANTEED"))
+                .andExpect(jsonPath("$.loans", hasSize(2)));
     }
 }

--- a/src/test/java/com/miguel/lendingservice/service/LoanServiceTest.java
+++ b/src/test/java/com/miguel/lendingservice/service/LoanServiceTest.java
@@ -1,0 +1,76 @@
+package com.miguel.lendingservice.service;
+
+import com.miguel.lendingservice.dto.LoanDTO;
+import com.miguel.lendingservice.dto.LoanRequest;
+import com.miguel.lendingservice.dto.LoanResponse;
+import com.miguel.lendingservice.model.LoanType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoanServiceTest {
+    private final String cpf = "275.484.389-23";
+    private final String name = "Vuxaywua Zukiagou";
+    private final String sp = "SP";
+    private LoanService loanService;
+
+    @BeforeEach
+    void setUp() {
+        loanService = new LoanService();
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {2000.00, 3000.00, 4000.00})
+    void salaryAtMost3000_returnsPersonalAndGuaranteed(double salary) {
+        LoanRequest request = new LoanRequest(26, cpf, name, BigDecimal.valueOf(salary), sp);
+        LoanResponse response = loanService.determineEligibleLoans(request);
+
+        assertNotNull(response);
+        assertEquals(name, response.customer());
+
+        List<LoanDTO> loans = response.loans();
+        assertEquals(2, loans.size());
+        assertTrue(loans.contains(new LoanDTO(LoanType.PERSONAL, 4)));
+        assertTrue(loans.contains(new LoanDTO(LoanType.GUARANTEED, 3)));
+    }
+
+    @Test
+    void salaryAbove5000_returnsConsignment() {
+        LoanRequest request = new LoanRequest(26, cpf, name, BigDecimal.valueOf(7000.00), sp);
+        LoanResponse response = loanService.determineEligibleLoans(request);
+        assertNotNull(response);
+        assertEquals(name, response.customer());
+        List<LoanDTO> loans = response.loans();
+        assertEquals(1, loans.size());
+        assertTrue(loans.contains(new LoanDTO(LoanType.CONSIGNMENT, 2)));
+    }
+
+    @Test
+    void salaryExactly5000_AgeAbove30_returnsOnlyConsignment() {
+        LoanRequest request = new LoanRequest(35, cpf, name, BigDecimal.valueOf(5000.00), sp);
+        LoanResponse response = loanService.determineEligibleLoans(request);
+
+        assertNotNull(response);
+        assertEquals(name, response.customer());
+
+        List<LoanDTO> loans = response.loans();
+        assertEquals(1, loans.size());
+        assertTrue(loans.contains(new LoanDTO(LoanType.CONSIGNMENT, 2)));
+    }
+
+    @Test
+    void salaryBetween3000And5000_NotSP_returnsNoLoans() {
+        LoanRequest request = new LoanRequest(26, cpf, name, BigDecimal.valueOf(4000.00), "RJ");
+        LoanResponse response = loanService.determineEligibleLoans(request);
+        assertNotNull(response);
+        assertEquals(name, response.customer());
+        List<LoanDTO> loans = response.loans();
+        assertTrue(loans.isEmpty());
+    }
+}


### PR DESCRIPTION
This PR introduces a set of unit tests to validate the loan eligibility logic based on different salary ranges, customer age, and location. It includes tests for the following scenarios:
- Customers with salaries below or equal to 3000, ensuring both personal and guaranteed loans are offered.
- Customers with salaries between 3000 and 5000 in São Paulo (SP), ensuring both personal and guaranteed loans are offered.
- Customers with salaries above 5000, verifying that only consignment loans are offered.
- Customers residing outside São Paulo with salaries between 3000 and 5000, ensuring no loans are offered.

Additionally, the tests have been organized to check edge cases like customers in different states and various salary brackets, ensuring the eligibility rules are correctly applied.

---