### PR TITLE
fix and extend test suite with new loan eligibility cases

### DIFF
--- a/src/test/java/com/miguel/lendingservice/service/LoanServiceTest.java
+++ b/src/test/java/com/miguel/lendingservice/service/LoanServiceTest.java
@@ -7,6 +7,7 @@ import com.miguel.lendingservice.model.LoanType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
@@ -18,6 +19,7 @@ class LoanServiceTest {
     private final String cpf = "275.484.389-23";
     private final String name = "Vuxaywua Zukiagou";
     private final String sp = "SP";
+    private final LoanType[] personalAndGuaranteedLoans = {LoanType.PERSONAL, LoanType.GUARANTEED};
     private LoanService loanService;
 
     @BeforeEach
@@ -26,39 +28,50 @@ class LoanServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(doubles = {2000.00, 3000.00, 4000.00})
-    void salaryAtMost3000_returnsPersonalAndGuaranteed(double salary) {
-        LoanRequest request = new LoanRequest(26, cpf, name, BigDecimal.valueOf(salary), sp);
-        LoanResponse response = loanService.determineEligibleLoans(request);
-
-        assertNotNull(response);
-        assertEquals(name, response.customer());
-
-        List<LoanDTO> loans = response.loans();
-        assertEquals(2, loans.size());
-        assertTrue(loans.contains(new LoanDTO(LoanType.PERSONAL, 4)));
-        assertTrue(loans.contains(new LoanDTO(LoanType.GUARANTEED, 3)));
-    }
-
-    @ParameterizedTest
-    @ValueSource(doubles = {5000.00, 7000.00})
-    void salaryAtLeast5000_ageAbove30_returnsOnlyConsignment(double salary) {
-        LoanRequest request = new LoanRequest(26, cpf, name, BigDecimal.valueOf(salary), sp);
-        LoanResponse response = loanService.determineEligibleLoans(request);
-        assertNotNull(response);
-        assertEquals(name, response.customer());
-        List<LoanDTO> loans = response.loans();
-        assertEquals(1, loans.size());
-        assertTrue(loans.contains(new LoanDTO(LoanType.CONSIGNMENT, 2)));
+    @ValueSource(doubles = {2999.99, 3000.00, 4000.00})
+    void salaryBelow5000_sp_returnsPersonalAndGuaranteedLoans(double salary) {
+        assertLoanTypes(new LoanRequest(26, cpf, name, BigDecimal.valueOf(salary), sp), personalAndGuaranteedLoans);
     }
 
     @Test
-    void salaryBetween3000And5000_NotSP_returnsNoLoans() {
-        LoanRequest request = new LoanRequest(26, cpf, name, BigDecimal.valueOf(4000.00), "RJ");
+    void salaryExactly3000_age30OrMore_notSp_returnsOnlyPersonalAndGuaranteedLoans() {
+        assertLoanTypes(new LoanRequest(30, cpf, name, BigDecimal.valueOf(3000), "RJ"), personalAndGuaranteedLoans);
+    }
+
+    @Test
+    void salaryExactly5000_sp_returnsPersonalGuaranteedAndConsignmentLoans() {
+        assertLoanTypes(new LoanRequest(26, cpf, name, BigDecimal.valueOf(5000), sp), LoanType.PERSONAL, LoanType.GUARANTEED, LoanType.CONSIGNMENT);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"5000.01, sp", "5000.00, rj", "5000.01, rj"})
+    void salaryAbove5000_returnsOnlyConsignmentLoan(Double salary, String state) {
+        assertLoanTypes(new LoanRequest(26, cpf, name, BigDecimal.valueOf(salary), state), LoanType.CONSIGNMENT);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"4000, RJ, 26", "4000, SP, 30"})
+    void salaryBetween3000And5000_noLoans(Double salary, String state, int age){
+        assertLoanTypes(new LoanRequest(age, cpf, name, BigDecimal.valueOf(salary), state));
+    }
+
+    private void assertLoanTypes(LoanRequest request, LoanType... expectedLoans) {
         LoanResponse response = loanService.determineEligibleLoans(request);
         assertNotNull(response);
         assertEquals(name, response.customer());
+
         List<LoanDTO> loans = response.loans();
-        assertTrue(loans.isEmpty());
+        assertEquals(expectedLoans.length, loans.size());
+        for (LoanType loanType : expectedLoans) {
+            assertTrue(loans.contains(new LoanDTO(loanType, getLoanRate(loanType))));
+        }
+    }
+
+    private int getLoanRate(LoanType loanType) {
+        return switch (loanType) {
+            case PERSONAL -> 4;
+            case GUARANTEED -> 3;
+            case CONSIGNMENT -> 2;
+        };
     }
 }


### PR DESCRIPTION
This PR updates the corresponding test suite. Key changes include:

- **Extending the test coverage** with additional scenarios:
  - Salary just below 5000 for specific locations (`SP`) now correctly returns the expected loan types.
  - Adjusted tests for age conditions with specific locations and salary ranges.
  - Added tests to handle cases where no loans are eligible.
  
This ensures that the loan eligibility system is robust.